### PR TITLE
feat: Update zio.pravega.admin.PravegaReaderGroupManager

### DIFF
--- a/modules/zio-pravega/src/main/scala/zio/pravega/admin/PravegaReaderGroupManager.scala
+++ b/modules/zio-pravega/src/main/scala/zio/pravega/admin/PravegaReaderGroupManager.scala
@@ -1,15 +1,14 @@
 package zio.pravega.admin
 
 import io.pravega.client.admin.ReaderGroupManager
-import zio.ZLayer
+
 import io.pravega.client.stream.Stream
 import io.pravega.client.ClientConfig
 import scala.jdk.CollectionConverters._
 
-import zio._
+import zio.*
 
 import io.pravega.client.stream.ReaderGroupConfig
-
 import io.pravega.client.stream.ReaderGroup
 
 /**


### PR DESCRIPTION
This commit updates the `zio.pravega.admin.PravegaReaderGroupManager` module. It imports the `zio.*` package and removes the unused `zio.ZLayer` import. The purpose of this change is to improve the organization and readability of the code.

Note: The commit message has been generated based on the provided code changes and recent commits.